### PR TITLE
Feat/tests endian helpers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 add_executable(super_modbus_tests
+    endian_helpers.cpp
+    gtest_test.cpp
     rtu_parser_read_hr.cpp
     rtu_parser_read_ir.cpp
 )

--- a/test/endian_helpers.cpp
+++ b/test/endian_helpers.cpp
@@ -1,0 +1,34 @@
+
+#include "endian_helpers.hpp"
+#include <gtest/gtest.h>
+#include <array>
+
+namespace {
+
+TEST(EndianHelpers, WordLE) {
+  constexpr uint16_t kVal{0x1234};
+  constexpr uint16_t kSwapped{0x3412};
+  auto result = supermodbus::le_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    EXPECT_EQ(result, kSwapped);
+  } else {
+    EXPECT_EQ(result, kVal);
+  }
+}
+
+TEST(EndianHelpers, WordBE) {
+  constexpr uint16_t kVal{0x1234};
+  constexpr uint16_t kSwapped{0x3412};
+  auto result = supermodbus::be_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    std::cout << "big\n";
+    EXPECT_EQ(result, kVal);
+  } else {
+    std::cout << "little\n";
+    EXPECT_EQ(result, kSwapped);
+  }
+}
+
+}  // namespace

--- a/test/endian_helpers.cpp
+++ b/test/endian_helpers.cpp
@@ -17,16 +17,38 @@ TEST(EndianHelpers, WordLE) {
   }
 }
 
+TEST(EndianHelpers, DWordLE) {
+  constexpr uint32_t kVal{0x12345678};
+  constexpr uint32_t kSwapped{0x78563412};
+  auto result = supermodbus::le_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    EXPECT_EQ(result, kSwapped);
+  } else {
+    EXPECT_EQ(result, kVal);
+  }
+}
+
 TEST(EndianHelpers, WordBE) {
   constexpr uint16_t kVal{0x1234};
   constexpr uint16_t kSwapped{0x3412};
   auto result = supermodbus::be_swap(kVal);
 
   if constexpr (std::endian::native == std::endian::big) {
-    std::cout << "big\n";
     EXPECT_EQ(result, kVal);
   } else {
-    std::cout << "little\n";
+    EXPECT_EQ(result, kSwapped);
+  }
+}
+
+TEST(EndianHelpers, DWordBE) {
+  constexpr uint32_t kVal{0x12345678};
+  constexpr uint32_t kSwapped{0x78563412};
+  auto result = supermodbus::be_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    EXPECT_EQ(result, kVal);
+  } else {
     EXPECT_EQ(result, kSwapped);
   }
 }

--- a/test/endian_helpers.cpp
+++ b/test/endian_helpers.cpp
@@ -29,6 +29,18 @@ TEST(EndianHelpers, DWordLE) {
   }
 }
 
+TEST(EndianHelpers, QWordLE) {
+  constexpr uint64_t kVal{0x123456789ABCDEF0};
+  constexpr uint64_t kSwapped{0xF0DEBC9A78563412};
+  auto result = supermodbus::le_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    EXPECT_EQ(result, kSwapped);
+  } else {
+    EXPECT_EQ(result, kVal);
+  }
+}
+
 TEST(EndianHelpers, WordBE) {
   constexpr uint16_t kVal{0x1234};
   constexpr uint16_t kSwapped{0x3412};
@@ -44,6 +56,18 @@ TEST(EndianHelpers, WordBE) {
 TEST(EndianHelpers, DWordBE) {
   constexpr uint32_t kVal{0x12345678};
   constexpr uint32_t kSwapped{0x78563412};
+  auto result = supermodbus::be_swap(kVal);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    EXPECT_EQ(result, kVal);
+  } else {
+    EXPECT_EQ(result, kSwapped);
+  }
+}
+
+TEST(EndianHelpers, QWordBE) {
+  constexpr uint64_t kVal{0x123456789ABCDEF0};
+  constexpr uint64_t kSwapped{0xF0DEBC9A78563412};
   auto result = supermodbus::be_swap(kVal);
 
   if constexpr (std::endian::native == std::endian::big) {


### PR DESCRIPTION
Add tests to cover endian_helpers.cpp (le_swap and be_swap functions).  Provide checks based on the endianness of the machine the tests are executed on.